### PR TITLE
Add optional Sniffle BLE pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Sniffle"]
+	path = Sniffle
+	url = https://github.com/nccgroup/Sniffle

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sniffle:
   serport: "/dev/ttyUSB0"     # your Sniffle serial device (e.g., /dev/ttyACM0)
   baudrate: 2000000           # use 921600 for older Sonoff CC2652P dongles
   advchan: 37                 # starting primary advertising channel
-  mode: active_scan           # active_scan | passive_scan | conn_follow
+  mode: conn_follow           # conn_follow (default, no -A); or active_scan | passive_scan
   extadv: true                # capture extended advertising
   longrange: false            # enable only if you need coded PHY
   rssi_min: -90
@@ -136,6 +136,8 @@ sniffle:
   target_irk:
   target_string:
   pcap_output:
+
+Note: `active_scan` (`-A`) has been observed to stall on some firmware/boards; the default `conn_follow` avoids passing `-A`. Switch to `active_scan` if your hardware/firmware handles it reliably.
 ```
 
 Run as root as usual: `sudo ./bin/blue_hydra`. The CUI will show `Sniffle status: ...` when this mode is active. If no local HCI adapter is present, BlueHydra continues with Sniffle; if an HCI is present, you can still fall back to the normal pipeline by leaving `sniffle.enabled` set to `false`.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,35 @@ An example for a script wrapping blue_hydra and creating a csv output after run 
 https://github.com/pwnieexpress/pwn_pad_sources/blob/develop/scripts/blue_hydra.sh
 This script will simply take a timestamp before blue_hydra starts, and then again after it exits, then grab a few interesting values from the db and output in csv format.
 
+## Sniffle Support (BLE only)
+
+BlueHydra can optionally use the bundled [Sniffle](https://github.com/nccgroup/Sniffle) submodule as a BLE capture source (BT5/4.x). When enabled, Sniffle replaces the btmon/ubertooth pipeline and feeds LE advertisements/scan responses directly into the BlueHydra UI/DB. Classic/BR-EDR data is not available in this mode, and devices will show `VERS=BTLE` (spec version isn’t inferred from advertisements).
+
+Requirements:
+
+* Sniffle-compatible hardware (e.g., TI CC26x2/CC13x2, CC1352, CC2652, Sonoff CC2652P).
+* Python 3 with pyserial (per the Sniffle README).
+
+Enable and configure in `blue_hydra.yml` (generated on first run):
+
+```
+sniffle:
+  enabled: false              # set true to use Sniffle instead of btmon/ubertooth
+  serport: "/dev/ttyUSB0"     # your Sniffle serial device (e.g., /dev/ttyACM0)
+  baudrate: 2000000           # use 921600 for older Sonoff CC2652P dongles
+  advchan: 37                 # starting primary advertising channel
+  mode: active_scan           # active_scan | passive_scan | conn_follow
+  extadv: true                # capture extended advertising
+  longrange: false            # enable only if you need coded PHY
+  rssi_min: -90
+  target_mac:
+  target_irk:
+  target_string:
+  pcap_output:
+```
+
+Run as root as usual: `sudo ./bin/blue_hydra`. The CUI will show `Sniffle status: ...` when this mode is active. If no local HCI adapter is present, BlueHydra continues with Sniffle; if an HCI is present, you can still fall back to the normal pipeline by leaving `sniffle.enabled` set to `false`.
+
 ## Helping with Development
 
 PR's should be targeted against the "develop" branch.

--- a/bin/blue_hydra
+++ b/bin/blue_hydra
@@ -160,14 +160,12 @@ begin
     status = runner.status
 
     unless status[:stopping]
-      threads =
-        if BlueHydra.sniffle_enabled?
-          [:sniffle_thread, :result_thread]
-        else
-          base = [:btmon_thread, :chunker_thread, :parser_thread, :result_thread]
-          base << :discovery_thread unless BlueHydra.config["file"]
-          base
-        end
+      threads = [:result_thread]
+      threads << :sniffle_thread    if status[:sniffle_thread]
+      threads << :btmon_thread      if status[:btmon_thread]
+      threads << :chunker_thread    if status[:chunker_thread]
+      threads << :parser_thread     if status[:parser_thread]
+      threads << :discovery_thread  if status[:discovery_thread]
 
       if BlueHydra.signal_spitter
         threads << :signal_spitter_thread

--- a/bin/blue_hydra
+++ b/bin/blue_hydra
@@ -160,16 +160,14 @@ begin
     status = runner.status
 
     unless status[:stopping]
-      threads = [
-        :btmon_thread,
-        :chunker_thread,
-        :parser_thread,
-        :result_thread
-      ]
-
-      unless BlueHydra.config["file"]
-        threads << :discovery_thread
-      end
+      threads =
+        if BlueHydra.sniffle_enabled?
+          [:sniffle_thread, :result_thread]
+        else
+          base = [:btmon_thread, :chunker_thread, :parser_thread, :result_thread]
+          base << :discovery_thread unless BlueHydra.config["file"]
+          base
+        end
 
       if BlueHydra.signal_spitter
         threads << :signal_spitter_thread

--- a/lib/blue_hydra.rb
+++ b/lib/blue_hydra.rb
@@ -65,7 +65,21 @@ module BlueHydra
     "ui_exc_filter_prox" => [],           # exclude ui filter by prox uuid / major /minor
     "ignore_mac"         => [],           # completely ignore a mac address, both ui and db
     "signal_spitter"     => false,        # make raw signal strength api available on localhost:1124
-    "chunker_debug"      => false
+    "chunker_debug"      => false,
+    "sniffle"            => {             # settings for Sniffle submodule integration
+      "enabled"               => false,
+      "serport"               => "/dev/ttyUSB0", # update to your Sniffle tty (e.g., /dev/ttyACM0)
+      "baudrate"              => 2_000_000,      # use 921600 on older Sonoff CC2652P dongles
+      "advchan"               => 37,
+      "mode"                  => "active_scan", # active_scan | passive_scan | conn_follow
+      "extadv"                => true,
+      "longrange"             => false,
+      "rssi_min"              => -90,
+      "target_mac"            => nil,
+      "target_irk"            => nil,
+      "target_string"         => nil,
+      "pcap_output"           => nil
+    }
   }
 
   # Create config file with defaults if missing or load and update.
@@ -152,6 +166,14 @@ module BlueHydra
                      else
                        Logger::INFO
                      end
+  end
+
+  def self.sniffle_config
+    @@config["sniffle"] || {}
+  end
+
+  def self.sniffle_enabled?
+    sniffle_config["enabled"]
   end
 
   initialize_logger
@@ -315,6 +337,7 @@ require 'blue_hydra/device'
 require 'blue_hydra/sync_version'
 require 'blue_hydra/cli_user_interface'
 require 'blue_hydra/cli_user_interface_tracker'
+require 'blue_hydra/sniffle_collector'
 
 # Here we enumerate the local hci adapter hardware address and make it
 # available as an internal value
@@ -329,7 +352,10 @@ end
 begin
   BlueHydra::LOCAL_ADAPTER_ADDRESS = BlueHydra::EnumLocalAddr.call.first
 rescue
-  if ENV["BLUE_HYDRA"] == "test"
+  if BlueHydra.sniffle_enabled?
+    BlueHydra.logger.warn("No local HCI adapter detected; continuing because Sniffle is enabled. Classic HCI features will be skipped.")
+    BlueHydra::LOCAL_ADAPTER_ADDRESS = nil
+  elsif ENV["BLUE_HYDRA"] == "test"
     BlueHydra::LOCAL_ADAPTER_ADDRESS = "JE:NK:IN:SJ:EN:KI"
     puts "Failed to find mac address for #{BlueHydra.config["bt_device"]}, faking for tests"
   else

--- a/lib/blue_hydra.rb
+++ b/lib/blue_hydra.rb
@@ -71,7 +71,7 @@ module BlueHydra
       "serport"               => "/dev/ttyUSB0", # update to your Sniffle tty (e.g., /dev/ttyACM0)
       "baudrate"              => 2_000_000,      # use 921600 on older Sonoff CC2652P dongles
       "advchan"               => 37,
-      "mode"                  => "active_scan", # active_scan | passive_scan | conn_follow
+      "mode"                  => "conn_follow", # active_scan | passive_scan | conn_follow (default no -A)
       "extadv"                => true,
       "longrange"             => false,
       "rssi_min"              => -90,

--- a/lib/blue_hydra/cli_user_interface.rb
+++ b/lib/blue_hydra/cli_user_interface.rb
@@ -347,15 +347,21 @@ HELP
             discovery_time = "not started"
           end
 
-          # check status of ubertooth
-          if scanner_status[:ubertooth]
-            if scanner_status[:ubertooth].class == Integer
-              ubertooth_time = Time.now.to_i - scanner_status[:ubertooth]
-            else
-              ubertooth_time = scanner_status[:ubertooth]
-            end
+          # check status of ubertooth or sniffle
+          if BlueHydra.sniffle_enabled?
+            ubertooth_label = "Sniffle status"
+            ubertooth_time = scanner_status[:sniffle] || "Starting..."
           else
-            ubertooth_time = "Starting detection..."
+            ubertooth_label = "Ubertooth status"
+            if scanner_status[:ubertooth]
+              if scanner_status[:ubertooth].class == Integer
+                ubertooth_time = Time.now.to_i - scanner_status[:ubertooth]
+              else
+                ubertooth_time = scanner_status[:ubertooth]
+              end
+            else
+              ubertooth_time = "Starting detection..."
+            end
           end
         end
 
@@ -391,7 +397,7 @@ HELP
         # about the status of the discovery and ubertooth timers from the
         # runner
         unless BlueHydra.config["file"]
-          pbuff <<  "Discovery status timer: #{discovery_time}, Ubertooth status: #{ubertooth_time}, Filter mode: #{filter_mode}\n"
+          pbuff <<  "Discovery status timer: #{discovery_time}, #{ubertooth_label}: #{ubertooth_time}, Filter mode: #{filter_mode}\n"
           lines += 1
         end
 

--- a/lib/blue_hydra/cli_user_interface.rb
+++ b/lib/blue_hydra/cli_user_interface.rb
@@ -350,7 +350,9 @@ HELP
           # check status of ubertooth or sniffle
           if BlueHydra.sniffle_enabled?
             ubertooth_label = "Sniffle status"
-            ubertooth_time = scanner_status[:sniffle] || "Starting..."
+            last_pkt = scanner_status[:sniffle_last_packet]
+            age = last_pkt ? "#{Time.now.to_i - last_pkt}s ago" : "no packets yet"
+            ubertooth_time = "#{scanner_status[:sniffle] || 'Starting...'} (last #{age})"
           else
             ubertooth_label = "Ubertooth status"
             if scanner_status[:ubertooth]

--- a/lib/blue_hydra/cli_user_interface.rb
+++ b/lib/blue_hydra/cli_user_interface.rb
@@ -347,23 +347,25 @@ HELP
             discovery_time = "not started"
           end
 
-          # check status of ubertooth or sniffle
-          if BlueHydra.sniffle_enabled?
-            ubertooth_label = "Sniffle status"
-            last_pkt = scanner_status[:sniffle_last_packet]
-            age = last_pkt ? "#{Time.now.to_i - last_pkt}s ago" : "no packets yet"
-            ubertooth_time = "#{scanner_status[:sniffle] || 'Starting...'} (last #{age})"
-          else
-            ubertooth_label = "Ubertooth status"
-            if scanner_status[:ubertooth]
-              if scanner_status[:ubertooth].class == Integer
-                ubertooth_time = Time.now.to_i - scanner_status[:ubertooth]
-              else
-                ubertooth_time = scanner_status[:ubertooth]
-              end
+          # check status of sniffle and ubertooth independently
+          sniffle_label = "Sniffle status"
+          last_pkt = scanner_status[:sniffle_last_packet]
+          sniffle_age = last_pkt ? "#{Time.now.to_i - last_pkt}s ago" : "no packets yet"
+          sniffle_time = if BlueHydra.sniffle_enabled?
+                           "#{scanner_status[:sniffle] || 'Starting...'} (last #{sniffle_age})"
+                         else
+                           "disabled"
+                         end
+
+          ubertooth_label = "Ubertooth status"
+          if scanner_status[:ubertooth]
+            if scanner_status[:ubertooth].class == Integer
+              ubertooth_time = Time.now.to_i - scanner_status[:ubertooth]
             else
-              ubertooth_time = "Starting detection..."
+              ubertooth_time = scanner_status[:ubertooth]
             end
+          else
+            ubertooth_time = "Starting detection..."
           end
         end
 
@@ -399,7 +401,7 @@ HELP
         # about the status of the discovery and ubertooth timers from the
         # runner
         unless BlueHydra.config["file"]
-          pbuff <<  "Discovery status timer: #{discovery_time}, #{ubertooth_label}: #{ubertooth_time}, Filter mode: #{filter_mode}\n"
+          pbuff <<  "Discovery status timer: #{discovery_time}, #{sniffle_label}: #{sniffle_time}, #{ubertooth_label}: #{ubertooth_time}, Filter mode: #{filter_mode}\n"
           lines += 1
         end
 

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -14,6 +14,8 @@ module BlueHydra
                   :ubertooth_thread,
                   :chunker_thread,
                   :parser_thread,
+                  :sniffle_collector,
+                  :sniffle_thread,
                   :signal_spitter_thread,
                   :empty_spittoon_thread,
                   :cui_status,
@@ -95,6 +97,8 @@ module BlueHydra
         self.result_queue    = Queue.new # parser thread  -> result thread
         self.info_scan_queue = Queue.new # result thread  -> discovery thread
         self.l2ping_queue    = Queue.new # result thread  -> discovery thread
+        self.scanner_status  = {}
+        self.cui_status      = {}
 
         # start the result processing thread
         start_result_thread
@@ -104,6 +108,14 @@ module BlueHydra
           @rssi_data_mutex = Mutex.new #this is used by parser thread too
           start_signal_spitter_thread
           start_empty_spittoon_thread
+        end
+
+        if BlueHydra.sniffle_enabled?
+          BlueHydra.logger.info("Sniffle enabled; using Sniffle collector instead of btmon/ubertooth")
+          start_sniffle_thread
+          start_cui_thread unless BlueHydra.daemon_mode
+          start_api_thread if BlueHydra.file_api
+          return
         end
 
         # start the thread responsible for parsing the chunks into little data
@@ -121,8 +133,6 @@ module BlueHydra
 
         # helper hashes for tracking status of the scanners and also the in
         # memory copy of data for the CUI
-        self.scanner_status  = {}
-        self.cui_status      = {}
 
         # another thread which operates the actual device discovery, not needed
         # if reading from a file since btmon will just be getting replayed
@@ -247,30 +257,31 @@ module BlueHydra
     # is alive or to exit gracefully
     def status
       x = {
-        raw_queue:         self.raw_queue.length,
-        chunk_queue:       self.chunk_queue.length,
-        result_queue:      self.result_queue.length,
-        info_scan_queue:   self.info_scan_queue.length,
-        l2ping_queue:      self.l2ping_queue.length,
-        btmon_thread:      self.btmon_thread.status,
-        chunker_thread:    self.chunker_thread.status,
-        parser_thread:     self.parser_thread.status,
-        result_thread:     self.result_thread.status,
+        raw_queue:         (self.raw_queue&.length || 0),
+        chunk_queue:       (self.chunk_queue&.length || 0),
+        result_queue:      (self.result_queue&.length || 0),
+        info_scan_queue:   (self.info_scan_queue&.length || 0),
+        l2ping_queue:      (self.l2ping_queue&.length || 0),
+        btmon_thread:      (self.btmon_thread&.status),
+        chunker_thread:    (self.chunker_thread&.status),
+        parser_thread:     (self.parser_thread&.status),
+        result_thread:     (self.result_thread&.status),
         stopping:          @stopping
       }
 
       unless BlueHydra.config["file"]
-        x[:discovery_thread] = self.discovery_thread.status
-        x[:ubertooth_thread] = self.ubertooth_thread.status if self.ubertooth_thread
+        x[:discovery_thread] = self.discovery_thread&.status
+        x[:ubertooth_thread] = self.ubertooth_thread&.status if self.ubertooth_thread
+        x[:sniffle_thread]   = self.sniffle_thread&.status
       end
 
       if BlueHydra.signal_spitter
-        x[:signal_spitter_thread] = self.signal_spitter_thread.status
-        x[:empty_spittoon_thread] = self.empty_spittoon_thread.status
+        x[:signal_spitter_thread] = self.signal_spitter_thread&.status
+        x[:empty_spittoon_thread] = self.empty_spittoon_thread&.status
       end
 
-      x[:cui_thread] = self.cui_thread.status unless BlueHydra.daemon_mode
-      x[:api_thread] = self.api_thread.status if BlueHydra.file_api
+      x[:cui_thread] = self.cui_thread&.status unless BlueHydra.daemon_mode
+      x[:api_thread] = self.api_thread&.status if BlueHydra.file_api
 
       x
     end
@@ -282,14 +293,16 @@ module BlueHydra
       @stopping = true
       BlueHydra.logger.info("Runner stopped. Exiting after clearing queue...")
       self.btmon_thread.kill if self.btmon_thread # stop this first thread so data stops flowing ...
+      self.sniffle_collector&.stop
+      self.sniffle_thread&.kill if self.sniffle_thread
       unless BlueHydra.config["file"] #then stop doing anything if we are doing anything
         self.discovery_thread.kill if self.discovery_thread
         self.ubertooth_thread.kill if self.ubertooth_thread
       end
 
       stop_condition = Proc.new do
-        [nil, false].include?(result_thread.status) ||
-        [nil, false].include?(parser_thread.status) ||
+        result_thread.nil? || [nil, false].include?(result_thread.status) ||
+        parser_thread.nil? || [nil, false].include?(parser_thread.status) ||
         self.result_queue.empty?
       end
 
@@ -362,6 +375,16 @@ module BlueHydra
           })
         end
       end
+    end
+
+    def start_sniffle_thread
+      BlueHydra.logger.info("Sniffle collector thread starting")
+      self.sniffle_collector = BlueHydra::SniffleCollector.new(self)
+      self.sniffle_thread = sniffle_collector.start
+    rescue => e
+      BlueHydra.logger.error("Sniffle thread #{e.message}")
+      e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
+      self.scanner_status[:sniffle] = "error" if self.scanner_status
     end
 
     def ubertooth_firmware_check(ubertooth_stderr)

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -110,26 +110,22 @@ module BlueHydra
           start_empty_spittoon_thread
         end
 
-        if BlueHydra.sniffle_enabled?
-          BlueHydra.logger.info("Sniffle enabled; using Sniffle collector instead of btmon/ubertooth")
-          start_sniffle_thread
-          start_cui_thread unless BlueHydra.daemon_mode
-          start_api_thread if BlueHydra.file_api
-          return
-        end
+        start_sniffle_thread if BlueHydra.sniffle_enabled?
+
+        hci_available = !!BlueHydra::LOCAL_ADAPTER_ADDRESS
 
         # start the thread responsible for parsing the chunks into little data
         # blobs to be sorted in the db
-        start_parser_thread
+        start_parser_thread if BlueHydra.config["file"] || hci_available
 
         # start the thread responsible for breaking the filtered btmon output
         # into chunks by device, basically a pre-parser
-        start_chunker_thread
+        start_chunker_thread if BlueHydra.config["file"] || hci_available
 
         # start the thread which runs the command, typically btmon so this is
         # the btmon thread but this thread will also run the xzcat, zcat or cat
         # commands for files
-        start_btmon_thread
+        start_btmon_thread if hci_available || BlueHydra.config["file"]
 
         # helper hashes for tracking status of the scanners and also the in
         # memory copy of data for the CUI
@@ -137,7 +133,7 @@ module BlueHydra
         # another thread which operates the actual device discovery, not needed
         # if reading from a file since btmon will just be getting replayed
         unless ENV["BLUE_HYDRA"] == "test"
-          start_discovery_thread unless BlueHydra.config["file"]
+          start_discovery_thread if !BlueHydra.config["file"] && hci_available
         end
 
         # start the thread responsible for printing the CUI to screen unless

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -805,6 +805,7 @@ module BlueHydra
     # helper method to push addresses intothe scan queues with a little
     # pre-processing
     def push_to_queue(mode, address)
+      local = BlueHydra::LOCAL_ADAPTER_ADDRESS
       case mode
       when :classic
         command = :info
@@ -812,13 +813,13 @@ module BlueHydra
         track_addr = address.split(":")[2,4].join(":")
 
         # do not send local adapter to be scanned y(>_<)y
-        return if track_addr == BlueHydra::LOCAL_ADAPTER_ADDRESS.split(":")[2,4].join(":")
+        return if local && track_addr == local.split(":")[2,4].join(":")
       when :le
         command = :leinfo
         track_addr = address
 
         # do not send local adapter to be scanned y(>_<)y
-        return if address == BlueHydra::LOCAL_ADAPTER_ADDRESS
+        return if local && address == local
       end
 
       # only scan if the info scan rate timeframe has elapsed

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -26,6 +26,7 @@ module BlueHydra
 
     def run
       cfg = BlueHydra.sniffle_config
+      idle_timeout = 30
       loop do
         break if @stop
         cmd = build_command(cfg)
@@ -36,6 +37,7 @@ module BlueHydra
             @wait_thr = wait_thr
             @io = stdout
             buffer = []
+            last_activity = Time.now
 
             BlueHydra.logger.debug("Sniffle process started: #{cmd.join(' ')}")
 
@@ -43,7 +45,18 @@ module BlueHydra
               break if @stop
 
               ready = IO.select([stdout], nil, nil, 1)
-              next unless ready
+              unless ready
+                if (Time.now - last_activity) > idle_timeout
+                  @runner.scanner_status[:sniffle] = "idle_restart"
+                  BlueHydra.logger.warn("Sniffle idle for #{idle_timeout}s, restarting capture")
+                  begin
+                    Process.kill("TERM", wait_thr.pid)
+                  rescue
+                  end
+                  break
+                end
+                next
+              end
 
               line = stdout.gets
               if line.nil?
@@ -51,6 +64,7 @@ module BlueHydra
                 BlueHydra.logger.debug("Sniffle stdout EOF")
                 break
               end
+              last_activity = Time.now
 
               # sniff_receiver prints blank lines between packets; use that to flush
               if line.strip.empty?

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -1,0 +1,223 @@
+module BlueHydra
+  # Simple reader for Sniffle's stdout. It spawns sniff_receiver.py with the
+  # configured flags, parses each printed packet block, and feeds BlueHydra
+  # result_queue and CUI state.
+  class SniffleCollector
+    attr_reader :thread
+
+    def initialize(runner)
+      @runner = runner
+      @result_queue = runner.result_queue
+      @stop = false
+    end
+
+    def start
+      @thread = Thread.new { run }
+    end
+
+    def stop
+      @stop = true
+      @io&.close rescue nil
+      @wait_thr&.kill rescue nil
+      @thread&.kill
+    end
+
+    private
+
+    def run
+      cfg = BlueHydra.sniffle_config
+      cmd = build_command(cfg)
+
+      @runner.scanner_status[:sniffle] = "starting"
+
+      Open3.popen2e(*cmd) do |_stdin, stdout, wait_thr|
+        @wait_thr = wait_thr
+        @io = stdout
+        buffer = []
+
+        stdout.each_line do |line|
+          break if @stop
+          # sniff_receiver prints blank lines between packets; use that to flush
+          if line.strip.empty?
+            process_block(buffer) unless buffer.empty?
+            buffer = []
+          else
+            buffer << line
+          end
+        end
+
+        process_block(buffer) unless buffer.empty?
+      end
+    rescue => e
+      BlueHydra.logger.error("Sniffle collector error: #{e.message}")
+      e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
+      @runner.scanner_status[:sniffle] = "error"
+    ensure
+      @runner.scanner_status[:sniffle] ||= "stopped"
+      @runner.scanner_status[:sniffle] = "stopped" if @runner.scanner_status[:sniffle] == "starting"
+    end
+
+    def build_command(cfg)
+      script = File.expand_path("../../Sniffle/python_cli/sniff_receiver.py", __dir__)
+      cmd = ["python3", script]
+      cmd += ["-s", cfg["serport"]] if cfg["serport"]
+      cmd += ["-b", cfg["baudrate"].to_s] if cfg["baudrate"]
+      cmd += ["-c", cfg["advchan"].to_s] if cfg["advchan"]
+      cmd << "-e" if cfg["extadv"]
+
+      case cfg["mode"]
+      when "active_scan"
+        cmd << "-A"
+      when "passive_scan"
+        cmd << "-a"
+      else # conn_follow / default
+        # sniff_receiver defaults to connection following
+      end
+
+      cmd << "-l" if cfg["longrange"]
+      cmd += ["-r", cfg["rssi_min"].to_s] if cfg["rssi_min"]
+      cmd += ["-m", cfg["target_mac"]] if cfg["target_mac"]
+      cmd += ["-i", cfg["target_irk"]] if cfg["target_irk"]
+      cmd += ["-S", cfg["target_string"]] if cfg["target_string"]
+      cmd += ["-o", cfg["pcap_output"]] if cfg["pcap_output"]
+      cmd
+    end
+
+    def process_block(lines)
+      attrs = parse_block(lines)
+      return unless attrs
+
+      @result_queue.push(attrs)
+
+      # update CUI status similarly to the parser thread
+      begin
+        tracker = BlueHydra::CliUserInterfaceTracker.new(@runner, [["  LE Sniffle"]], attrs, attrs[:address].first)
+        tracker.update_cui_status
+      rescue => e
+        BlueHydra.logger.debug("Sniffle CUI update error: #{e.message}")
+      end
+
+      @runner.scanner_status[:sniffle] = "running"
+    end
+
+    def parse_block(lines)
+      first = lines[0] || ""
+      timestamp = Time.now.to_i
+      rssi = (first[/RSSI:\s*(-?\d+)/, 1] || "-99").to_i
+
+      ad_type_line = lines.find { |ln| ln.start_with?("Ad Type:") } || ""
+      adv_type = ad_type_line.split(":")[1].to_s.strip
+
+      adv_line = lines.find { |ln| ln.start_with?("AdvA:") }
+      return nil unless adv_line
+      address = adv_line[/AdvA:\s*([0-9A-Fa-f:]+)/, 1]
+      return nil unless address
+
+      addr_note = adv_line[/\(([^)]+)\)/, 1]
+      addr_type = addr_note&.downcase&.include?("public") ? "public" : "random"
+
+      bytes = extract_bytes(lines)
+      adv_data = extract_adv_data(bytes)
+      ad_structs = parse_ad_structs(adv_data)
+
+      attrs = {}
+      set_attr(attrs, :address, address.upcase)
+      set_attr(attrs, :le_mode, true)
+      set_attr(attrs, :last_seen, timestamp)
+      set_attr(attrs, :le_rssi, {t: timestamp, rssi: "#{rssi} dBm"})
+      set_attr(attrs, :le_address_type, addr_type)
+      set_attr(attrs, :le_random_address_type, addr_note) if addr_note
+
+      ad_structs.each do |struct|
+        case struct[:type]
+        when 0x09, 0x08 # Complete / Shortened local name
+          set_attr(attrs, :name, struct[:value])
+        when 0x01 # Flags
+          set_attr(attrs, :le_flags, struct[:raw_hex])
+        when 0x0a # TX Power
+          set_attr(attrs, :le_tx_power, struct[:value])
+        when 0xff # Manufacturer specific data
+          set_attr(attrs, :le_company_data, struct[:raw_hex])
+          set_attr(attrs, :company, struct[:company]) if struct[:company]
+        when 0x02, 0x03, 0x06, 0x07 # Service UUIDs
+          struct[:uuids].each { |uuid| set_attr(attrs, :le_service_uuids, uuid) }
+        when 0x19 # Appearance
+          set_attr(attrs, :appearance, struct[:appearance]) if struct[:appearance]
+        end
+      end
+
+      attrs
+    end
+
+    def extract_bytes(lines)
+      bytes = []
+      lines.select { |ln| ln.strip.start_with?("0x") }.each do |ln|
+        ln.split(":")[1].to_s.scan(/[0-9A-Fa-f]{2}/).each do |hx|
+          bytes << hx.to_i(16)
+        end
+      end
+      bytes
+    end
+
+    def extract_adv_data(bytes)
+      return [] if bytes.length < 8
+      payload_len = bytes[1] || 0
+      payload = bytes[2, payload_len] || []
+      payload[6..-1] || []
+    end
+
+    def parse_ad_structs(ad_bytes)
+      structs = []
+      i = 0
+      while i < ad_bytes.length
+        len = ad_bytes[i].to_i
+        break if len == 0
+        break if (i + len) >= ad_bytes.length + 1
+
+        type = ad_bytes[i + 1]
+        value_bytes = ad_bytes[(i + 2)..(i + len)] || []
+
+        case type
+        when 0x09, 0x08
+          value = bytes_to_utf8(value_bytes)
+          structs << {type: type, value: value, raw_hex: hex(value_bytes)}
+        when 0x0a
+          val = value_bytes.first.to_i
+          val -= 256 if val > 127
+          structs << {type: type, value: val, raw_hex: hex(value_bytes)}
+        when 0xff
+          company_id = value_bytes.length >= 2 ? (value_bytes[0] + (value_bytes[1] << 8)) : nil
+          company = company_id ? "Company ID 0x#{format('%04x', company_id)}" : nil
+          structs << {type: type, company: company, raw_hex: hex(value_bytes)}
+        when 0x02, 0x03 # 16-bit UUIDs
+          uuids = value_bytes.each_slice(2).map { |pair| format('%04x', (pair[0].to_i + (pair[1].to_i << 8))) }
+          structs << {type: type, uuids: uuids, raw_hex: hex(value_bytes)}
+        when 0x06, 0x07 # 128-bit UUIDs
+          uuids = value_bytes.each_slice(16).map { |blk| hex(blk) }
+          structs << {type: type, uuids: uuids, raw_hex: hex(value_bytes)}
+        when 0x19
+          appearance = value_bytes.length >= 2 ? format('0x%04x', value_bytes[0].to_i + (value_bytes[1].to_i << 8)) : nil
+          structs << {type: type, appearance: appearance, raw_hex: hex(value_bytes)}
+        else
+          structs << {type: type, raw_hex: hex(value_bytes)}
+        end
+
+        i += (len + 1)
+      end
+      structs
+    end
+
+    def bytes_to_utf8(bytes)
+      bytes.pack('C*').force_encoding('UTF-8').encode('UTF-8', invalid: :replace, undef: :replace)
+    end
+
+    def hex(bytes)
+      bytes.map { |b| format('%02x', b) }.join
+    end
+
+    def set_attr(hash, key, val)
+      hash[key] ||= []
+      hash[key] << val
+    end
+  end
+end

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -37,6 +37,8 @@ module BlueHydra
             @io = stdout
             buffer = []
 
+            BlueHydra.logger.debug("Sniffle process started: #{cmd.join(' ')}")
+
             loop do
               break if @stop
 
@@ -46,6 +48,7 @@ module BlueHydra
               line = stdout.gets
               if line.nil?
                 @runner.scanner_status[:sniffle] = "stopped (EOF)"
+                BlueHydra.logger.debug("Sniffle stdout EOF")
                 break
               end
 
@@ -54,6 +57,7 @@ module BlueHydra
                 unless buffer.empty?
                   begin
                     process_block(buffer)
+                    BlueHydra.logger.debug("Sniffle processed block, last_packet=#{@runner.scanner_status[:sniffle_last_packet]}")
                   rescue => e
                     BlueHydra.logger.error("Sniffle parse error: #{e.message}")
                     e.backtrace.each { |ln| BlueHydra.logger.error(ln) }

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -26,13 +26,10 @@ module BlueHydra
 
     def run
       cfg = BlueHydra.sniffle_config
-      idle_timeout = 20
-
       loop do
         break if @stop
         cmd = build_command(cfg)
         @runner.scanner_status[:sniffle] = "starting"
-        last_packet = Time.now
 
         begin
           Open3.popen2e(*cmd) do |_stdin, stdout, wait_thr|
@@ -44,18 +41,7 @@ module BlueHydra
               break if @stop
 
               ready = IO.select([stdout], nil, nil, 1)
-              unless ready
-                if (Time.now - last_packet) > idle_timeout
-                  @runner.scanner_status[:sniffle] = "idle_restart"
-                  BlueHydra.logger.warn("Sniffle idle for #{idle_timeout}s, restarting capture")
-                  begin
-                    Process.kill("TERM", wait_thr.pid)
-                  rescue
-                  end
-                  break
-                end
-                next
-              end
+              next unless ready
 
               line = stdout.gets
               if line.nil?
@@ -67,7 +53,6 @@ module BlueHydra
               if line.strip.empty?
                 unless buffer.empty?
                   process_block(buffer)
-                  last_packet = Time.now
                   buffer = []
                 end
               else

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -59,7 +59,8 @@ module BlueHydra
 
     def build_command(cfg)
       script = File.expand_path("../../Sniffle/python_cli/sniff_receiver.py", __dir__)
-      cmd = ["python3", script]
+      # -u to keep stdout unbuffered so we don't stall ingestion
+      cmd = ["python3", "-u", script]
       cmd += ["-s", cfg["serport"]] if cfg["serport"]
       cmd += ["-b", cfg["baudrate"].to_s] if cfg["baudrate"]
       cmd += ["-c", cfg["advchan"].to_s] if cfg["advchan"]

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -52,7 +52,12 @@ module BlueHydra
               # sniff_receiver prints blank lines between packets; use that to flush
               if line.strip.empty?
                 unless buffer.empty?
-                  process_block(buffer)
+                  begin
+                    process_block(buffer)
+                  rescue => e
+                    BlueHydra.logger.error("Sniffle parse error: #{e.message}")
+                    e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
+                  end
                   buffer = []
                 end
               else
@@ -106,6 +111,7 @@ module BlueHydra
       return unless attrs
 
       @result_queue.push(attrs)
+      @runner.scanner_status[:sniffle_last_packet] = Time.now.to_i
 
       # update CUI status similarly to the parser thread
       begin

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -26,35 +26,67 @@ module BlueHydra
 
     def run
       cfg = BlueHydra.sniffle_config
-      cmd = build_command(cfg)
+      idle_timeout = 20
 
-      @runner.scanner_status[:sniffle] = "starting"
+      loop do
+        break if @stop
+        cmd = build_command(cfg)
+        @runner.scanner_status[:sniffle] = "starting"
+        last_packet = Time.now
 
-      Open3.popen2e(*cmd) do |_stdin, stdout, wait_thr|
-        @wait_thr = wait_thr
-        @io = stdout
-        buffer = []
-
-        stdout.each_line do |line|
-          break if @stop
-          # sniff_receiver prints blank lines between packets; use that to flush
-          if line.strip.empty?
-            process_block(buffer) unless buffer.empty?
+        begin
+          Open3.popen2e(*cmd) do |_stdin, stdout, wait_thr|
+            @wait_thr = wait_thr
+            @io = stdout
             buffer = []
-          else
-            buffer << line
+
+            loop do
+              break if @stop
+
+              ready = IO.select([stdout], nil, nil, 1)
+              unless ready
+                if (Time.now - last_packet) > idle_timeout
+                  @runner.scanner_status[:sniffle] = "idle_restart"
+                  BlueHydra.logger.warn("Sniffle idle for #{idle_timeout}s, restarting capture")
+                  begin
+                    Process.kill("TERM", wait_thr.pid)
+                  rescue
+                  end
+                  break
+                end
+                next
+              end
+
+              line = stdout.gets
+              if line.nil?
+                @runner.scanner_status[:sniffle] = "stopped (EOF)"
+                break
+              end
+
+              # sniff_receiver prints blank lines between packets; use that to flush
+              if line.strip.empty?
+                unless buffer.empty?
+                  process_block(buffer)
+                  last_packet = Time.now
+                  buffer = []
+                end
+              else
+                buffer << line
+              end
+            end
+
+            process_block(buffer) unless buffer.empty?
           end
+        rescue => e
+          BlueHydra.logger.error("Sniffle collector error: #{e.message}")
+          e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
+          @runner.scanner_status[:sniffle] = "error"
+        ensure
+          @runner.scanner_status[:sniffle] ||= "stopped"
         end
 
-        process_block(buffer) unless buffer.empty?
+        sleep 1 unless @stop
       end
-    rescue => e
-      BlueHydra.logger.error("Sniffle collector error: #{e.message}")
-      e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
-      @runner.scanner_status[:sniffle] = "error"
-    ensure
-      @runner.scanner_status[:sniffle] ||= "stopped"
-      @runner.scanner_status[:sniffle] = "stopped" if @runner.scanner_status[:sniffle] == "starting"
     end
 
     def build_command(cfg)

--- a/lib/blue_hydra/sniffle_collector.rb
+++ b/lib/blue_hydra/sniffle_collector.rb
@@ -37,6 +37,7 @@ module BlueHydra
             @wait_thr = wait_thr
             @io = stdout
             buffer = []
+            buffer_started_at = nil
             last_activity = Time.now
 
             BlueHydra.logger.debug("Sniffle process started: #{cmd.join(' ')}")
@@ -46,6 +47,20 @@ module BlueHydra
 
               ready = IO.select([stdout], nil, nil, 1)
               unless ready
+                # timed flush in case we never saw a blank line separator
+                if buffer_started_at && (Time.now - buffer_started_at) > 2
+                  begin
+                    process_block(buffer)
+                    BlueHydra.logger.debug("Sniffle timed flush, last_packet=#{@runner.scanner_status[:sniffle_last_packet]}")
+                  rescue => e
+                    BlueHydra.logger.error("Sniffle parse error (timed flush): #{e.message}")
+                    e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
+                  end
+                  buffer = []
+                  buffer_started_at = nil
+                  last_activity = Time.now
+                end
+
                 if (Time.now - last_activity) > idle_timeout
                   @runner.scanner_status[:sniffle] = "idle_restart"
                   BlueHydra.logger.warn("Sniffle idle for #{idle_timeout}s, restarting capture")
@@ -77,8 +92,10 @@ module BlueHydra
                     e.backtrace.each { |ln| BlueHydra.logger.error(ln) }
                   end
                   buffer = []
+                  buffer_started_at = nil
                 end
               else
+                buffer_started_at ||= Time.now
                 buffer << line
               end
             end


### PR DESCRIPTION
Summary
- Adds Sniffle as an optional BLE source via submodule; LE-only.
- CUI shows “Sniffle status”; VERS shows BTLE. Opt-in via blue_hydra.yml (defaults: /dev/ttyUSB0, 2_000_000 baud; use 921600 for older Sonoff CC2652P).

Testing / Disclosure
- Lightly tested with a flashed Sonoff CC2652P on the latest Sniffle firmware (active scan, extended ads).
- AI assistance was used to draft and implement this change (tested by me before submission).
